### PR TITLE
Add / Implementación de endpoints para eliminar y consultar turnos mediante rol

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 		<url/>
 	</scm>
 	<properties>
-		<java.version>24</java.version>
+		<java.version>17</java.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/src/main/java/com/shiftmanagement/app_core/controllers/ShiftController.java
+++ b/src/main/java/com/shiftmanagement/app_core/controllers/ShiftController.java
@@ -8,7 +8,11 @@ import com.shiftmanagement.app_core.services.ShiftService;
 
 import java.util.List;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -31,6 +35,41 @@ public class ShiftController {
     public void postShift(@RequestBody Shift shift) {
         shiftService.generateShift(shift);
     }
-    
-    
+
+    /**
+     * This endpoint deletes a shift identified by its unique ID. This method uses the ShiftService to perform the operation 
+     * and handles errors if the shift doesn't exist.
+     * @param id the unique identifier of the shift to delete; must not be null or empty.
+     * 
+     * We get responses of type 200 if the action was completed or 404 if it was not found.
+     */
+    @DeleteMapping("/{id}")
+    public ResponseEntity<String> deleteShift(@PathVariable String id) {
+        try {
+            shiftService.deleteShift(id);
+            return ResponseEntity.ok("Shift deleted successfully.");
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+        }
+    }
+
+    /**
+     * This endpoint allows you to retrieve a list of shifts filtered by the role field. If no shifts are found with that role, 
+     * a 404 Not Found response is returned.
+     * @param role the role to filter shifts by; must not be null or empty.
+     */
+    @GetMapping("/role/{role}")
+    public ResponseEntity<?> getShiftsByRole(@PathVariable String role) {
+        try {
+            List<Shift> shifts = shiftService.getShiftsByRole(role);
+            if (shifts.isEmpty()) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body("No shifts found for role: " + role);
+            }
+            return ResponseEntity.ok(shifts);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body("No shifts found for role: " + role);
+        }
+    }
 }

--- a/src/main/java/com/shiftmanagement/app_core/model/Shift.java
+++ b/src/main/java/com/shiftmanagement/app_core/model/Shift.java
@@ -19,6 +19,8 @@ public class Shift {
     private LocalDateTime createdAt;
     private ShiftStatus status;
 
+    private String role;
+
     public Shift(String userId) {
         this.userId = userId;
     }
@@ -67,5 +69,12 @@ public class Shift {
     }
 
     
+    public String getRole() {
+        return role;
+    }
+    
+    public void setRole(String role) {
+        this.role = role;
+    }
 
 }

--- a/src/main/java/com/shiftmanagement/app_core/repository/ShiftRepository.java
+++ b/src/main/java/com/shiftmanagement/app_core/repository/ShiftRepository.java
@@ -1,6 +1,7 @@
 package com.shiftmanagement.app_core.repository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import org.springframework.data.mongodb.repository.MongoRepository;
 
@@ -8,5 +9,18 @@ import com.shiftmanagement.app_core.model.Shift;
 
 public interface ShiftRepository extends MongoRepository<Shift,String> {
     long countBySpecialtyIdAndCreatedAtBetween(String specialtyId, LocalDateTime startOfDay, LocalDateTime endOfDay);
+
+    /** 
+     * Taking into account the methods of MongoRepository, we can invoke the deletion of a shift by the ID
+     * @param id: the ID of the shift to delete.
+     */
+    void deleteById(String id);
     
+    /**
+     * This method searches for all shifts starting from a role
+     * @param role: this role is defined in the Shift class
+     * @return a list of shifts that match the role
+     */
+    List<Shift> findByRole(String role);
+
 }

--- a/src/main/java/com/shiftmanagement/app_core/services/ShiftService.java
+++ b/src/main/java/com/shiftmanagement/app_core/services/ShiftService.java
@@ -3,7 +3,7 @@ package com.shiftmanagement.app_core.services;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.List;
+import java.util.*;
 
 import org.springframework.stereotype.Service;
 
@@ -42,7 +42,36 @@ public class ShiftService {
     public List<Shift> getShifts(){
         return shiftRepository.findAll();
     }
-    
+
+    /**
+     * This method first checks whether a shift with the given ID exists in the database.
+     * If it does, it proceeds to delete it. If not, it throws an IllegalArgumentException.
+     * 
+     * We use optional since we are expecting one or no results by searching for the ID.
+     * 
+     * @param id the unique identifier of the shift to delete; must not be null or empty.
+    */
+    public void deleteShift(String id){
+        Optional<Shift> shift = shiftRepository.findById(id);
+        if (shift.isPresent()) {
+            shiftRepository.deleteById(id);
+        } else {
+            throw new IllegalArgumentException("No shift found with ID: " + id);
+        }
+    }
+
+    /**
+     * This method searches for all shifts starting from a role
+     * @param role: this role is defined in the Shift class
+     * @return a list of shifts that match the role
+     */
+    public List<Shift> getShiftsByRole(String role) {
+        List<Shift> shifts = shiftRepository.findByRole(role);
+        if (shifts == null || shifts.isEmpty()) {
+            throw new IllegalArgumentException("No shifts found for role: " + role);
+        }
+        return shifts;
+    }
 }
 
 


### PR DESCRIPTION
implementación endpoints para eliminar y consultar turnos mediante ID y rol, elementos agregados: 

- model/shift: Se definió el atributo "rol" de tipo String, acompañado de su respectivo getter y setter.

- repository/ShiftRepository: Se definieron dos métodos el primero para borrar por id que recibe como parámetro el id y el segundo para realizar una búsqueda de acuerdo a los roles y devuelve una lista.
 
- services/ShiftService: Desarrollo de los métodos definidos en el repositorio, se les da un manejo de errores.

- controllers/ShiftController: se agregaron dos endpoints el primero "deleteShift" el cual su funcionalidad es eliminar un turno mediante su ID, el segundo endpoint "getShiftsByRole" sirve para filtrar los turnos mediante un rol especifico.